### PR TITLE
Fix missing configuration

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
+        <tab id="magesuite" translate="label" sortOrder="300">
+            <label>MageSuite</label>
+        </tab>
         <section id="checkout_newsletter_subscription" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0">
             <label>Checkout Newsletter Subscription</label>
             <tab>magesuite</tab>


### PR DESCRIPTION
If only this extension is used, the MageSuite tab is not defined and hence, the configuration is not shown at all. This should fix it and uses the same code e.g. used here:

https://github.com/magesuite/seo-product-metatag-generation/blob/30ab3e85e8f9ac656f0cb5a366c1e15dba96c5cd/etc/adminhtml/system.xml#L5-L7